### PR TITLE
add customer first and last name to customers model

### DIFF
--- a/models/customers.sql
+++ b/models/customers.sql
@@ -48,6 +48,8 @@ final as (
 
     select
         customers.customer_id,
+        customers.first_name,
+        customers.last_name,
         customer_orders.first_order,
         customer_orders.most_recent_order,
         customer_orders.number_of_orders,


### PR DESCRIPTION
Two columns: `first_name` and `last_name` exist in `schema.yml` but aren't materialized in the `customers` table.

I wasn't sure if these were meant to be skipped because they're tagged as "PII"? In this PR I added the two missing columns to the `customers` table but maybe the point is that they shouldn't appear. In that case should they be removed from `schema.yml` also?