### PR TITLE
remove mention of total_order_amount field

### DIFF
--- a/models/schema.yml
+++ b/models/schema.yml
@@ -26,9 +26,6 @@ models:
       - name: number_of_orders
         description: Count of the number of orders a customer has placed
 
-      - name: total_order_amount
-        description: Total value (AUD) of a customer's orders
-
   - name: orders
     description: This table has basic information about orders, as well as some derived facts based on payments
 


### PR DESCRIPTION
Greetings !

I was using the jaffle shop repo to test out the [dbt-metabase](https://github.com/gouline/dbt-metabase) tool and i kept getting this pesky error:

    WARNING  Column TOTAL_ORDER_AMOUNT not found in ANALYTICS.CUSTOMERS model

Turns out in jaffle shop we are documenting a column `total_order_amount` that does not actually exist, and this causes dbt-metabase to fail.