### PR TITLE
test primary key validation

### DIFF
--- a/models/schema.yml
+++ b/models/schema.yml
@@ -2,7 +2,15 @@ version: 2
 
 models:
   - name: customers
+
+    config:
+      contract:
+        enforced: true
+
     description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
+    constraints:
+      - type: primary_key
+        columns: [customer_id]
 
     columns:
       - name: customer_id
@@ -10,38 +18,48 @@ models:
         tests:
           - unique
           - not_null
+        data_type: integer
+        constraints:
+          - type: primary_key
 
       - name: first_name
         description: Customer's first name. PII.
+        data_type: string
+        constraints:
+          - type: primary_key
 
       - name: last_name
+        data_type: string
         description: Customer's last name. PII.
 
       - name: first_order
+        data_type: date
         description: Date (UTC) of a customer's first order
 
       - name: most_recent_order
+        data_type: date
         description: Date (UTC) of a customer's most recent order
 
       - name: number_of_orders
+        data_type: bigint
         description: Count of the number of orders a customer has placed
 
-      - name: total_order_amount
-        description: Total value (AUD) of a customer's orders
+      - name: customer_lifetime_value
+        data_type: bigint
 
   - name: orders
     description: This table has basic information about orders, as well as some derived facts based on payments
 
     columns:
       - name: order_id
-        tests:
+        data_tests:
           - unique
           - not_null
         description: This is a unique identifier for an order
 
       - name: customer_id
         description: Foreign key to the customers table
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('customers')
@@ -52,31 +70,31 @@ models:
 
       - name: status
         description: '{{ doc("orders_status") }}'
-        tests:
+        data_tests:
           - accepted_values:
               values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
 
       - name: amount
         description: Total amount (AUD) of the order
-        tests:
+        data_tests:
           - not_null
 
       - name: credit_card_amount
         description: Amount of the order (AUD) paid for by credit card
-        tests:
+        data_tests:
           - not_null
 
       - name: coupon_amount
         description: Amount of the order (AUD) paid for by coupon
-        tests:
+        data_tests:
           - not_null
 
       - name: bank_transfer_amount
         description: Amount of the order (AUD) paid for by bank transfer
-        tests:
+        data_tests:
           - not_null
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
-        tests:
+        data_tests:
           - not_null

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -25,8 +25,6 @@ models:
       - name: first_name
         description: Customer's first name. PII.
         data_type: string
-        constraints:
-          - type: primary_key
 
       - name: last_name
         data_type: string


### PR DESCRIPTION
dbt parse succeeds when multiple primary keys are defined
```
❯ dbt parse
18:41:06  Running dbt...
18:41:06  target not specified in profile 'postgres', using 'default'
18:41:06  Registered adapter: postgres=1.8.0-a1
18:41:06  Performance info: /Users/michelleark/src/jaffle_shop/target/perf_info.json
```

but dbt run fails because the warehouse (postgres in this case) does not support multiple primary keys on a table (which makes sense)
```
18:41:26    Database Error in model customers (models/customers.sql)
  multiple primary keys for table "customers__dbt_tmp" are not allowed
  LINE 13:     first_name TEXT primary key,
                               ^
  compiled Code at target/run/jaffle_shop/models/customers.sql
18:41:26  
18:41:26  Done. PASS=4 WARN=0 ERROR=1 SKIP=0 TOTAL=5
```

should we be raising parse-time errors instead?