### PR TITLE
added a unit test to the jaffle_shop repo

### DIFF
--- a/models/staging/unit_tests.yml
+++ b/models/staging/unit_tests.yml
@@ -1,0 +1,12 @@
+unit_tests:
+  - name: test_dollar_conversion # this is the unique name of the test
+    model: stg_payments # name of the model I'm unit testing
+    given: # the mock data for your inputs
+      - input: ref('raw_payments')
+        rows:
+         - {id: 1, amount: 1000}
+         - {id: 2, amount: 50}
+    expect: # the expected output given the inputs above
+      rows:
+        - {payment_id: 1, amount: 10}
+        - {payment_id: 2, amount: 0.5}


### PR DESCRIPTION
Coming in dbt-core 1.8, we are adding support for native unit testing! I'm creating this PR to add a unit test to update the `jaffle_shop` repo with a unit test. 

We may also want to update the `dbt_project.yml`:
```
require-dbt-version: [">=1.8.0", "<2.0.0"]
```
since unit tests are only available in version 1.8 and above.

Logs of successful unit test:
```
(snowflake-latest) ➜  jaffle_shop git:(successful_unit_test) ✗ dbt test --select test_type:unit
16:56:19  Running with dbt=1.8.0-a1
16:56:20  Registered adapter: snowflake=1.8.0-a1
16:56:20  Unable to do partial parsing because a project config has changed
16:56:21  [WARNING]: Deprecated functionality
The `tests` config has been renamed to `data_tests`. Please update your
`dbt_project.yml` configuration to reflect this change.
16:56:22  Found 5 models, 3 seeds, 20 data_tests, 441 macros, 1 unit_test
16:56:22  
16:56:22  Concurrency: 8 threads (target='snowflake')
16:56:22  
16:56:22  1 of 1 START unit_test stg_payments::test_dollar_conversion .................... [RUN]
16:56:24  1 of 1 PASS stg_payments::test_dollar_conversion ............................... [PASS in 1.45s]
16:56:24  
16:56:24  Finished running 1 unit_test in 0 hours 0 minutes and 2.06 seconds (2.06s).
16:56:24  
16:56:24  Completed successfully
16:56:24  
16:56:24  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

We may also want to update `tests:` to `data_tests:`